### PR TITLE
"allow-silent-join-quit: false" set to true

### DIFF
--- a/Essentials/config.yml
+++ b/Essentials/config.yml
@@ -405,7 +405,7 @@ death-messages: false
 # Should players with permissions be able to join and part silently?
 # You can control this with essentials.silentjoin and essentials.silentquit permissions if it is enabled.
 # In addition, people with essentials.silentjoin.vanish will be vanished on join.
-allow-silent-join-quit: false
+allow-silent-join-quit: true
 
 # You can set a custom join message here, set to "none" to disable.
 # You may use color codes, use {USERNAME} the player's name or {PLAYER} for the player's displayname.


### PR DESCRIPTION
Will allow people to use essentials.silentjoin and essentials.silentquit to stop these Dirty yellow message :P (Useful for command block servers with custom join messages :D)